### PR TITLE
Updates POI dependency to 3.16 due to CVE-2017-5644

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-Excel-Import plugin uses Apache POI [http://poi.apache.org/] library (v 3.6) to parse Excel files.  
+Excel-Import plugin uses Apache POI [http://poi.apache.org/] library (v 3.16) to parse Excel files.  
 
 It's useful for either bootstrapping data, or when you want to allow your users to enter some data using Excel spreadsheets. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,10 +50,10 @@ dependencies {
     testCompile "org.grails:grails-plugin-testing"
 
     compile 'org.grails.plugins:joda-time:2.0.0'
-    compile 'org.apache.poi:poi:3.8'
+    compile 'org.apache.poi:poi:3.16'
 
     //xlxs file support
-    compile 'org.apache.poi:poi-ooxml:3.8'
+    compile 'org.apache.poi:poi-ooxml:3.16'
     compile 'org.apache.xmlbeans:xmlbeans:2.6.0'
 }
 


### PR DESCRIPTION
(https://nvd.nist.gov/vuln/detail/CVE-2017-5644)

All this does is update the Apache POI dependency to the latest upstream version (from 3.8 to 3.16).  The tests are passing.

According to the [Apache POI Changelog](https://poi.apache.org/changes.html#3.16), there have been some changes that impact backwards compatibility.