### PR TITLE
fix bug in AbstractExcelImporter.evaluateAllFormulaCells()

### DIFF
--- a/src/main/groovy/org/grails/plugins/excelimport/AbstractExcelImporter.groovy
+++ b/src/main/groovy/org/grails/plugins/excelimport/AbstractExcelImporter.groovy
@@ -53,15 +53,18 @@ public abstract class AbstractExcelImporter extends imexporter.AbstractImexporte
 		return this
 	}
 
-	def evaluateAllFormulaCells() {
+	def evaluateAllFormulaCells(boolean inCell = false) {
 		for(int sheetNum = 0; sheetNum < workbook.getNumberOfSheets(); sheetNum++) {
 			def sheet = workbook.getSheetAt(sheetNum);
 			for(def r : sheet) {
 				for(def c : r) {
-					if(c.getCellType() == Cell.CELL_TYPE_FORMULA) {
-//						if(c.getCellValue()==null || c.getCellValue() == '' || c.getCellValue() == 0){
+					if(c.getCellType() == CellType.FORMULA) {
+ 						if(inCell) {
+							evaluator.evaluateInCell(c);
+ 						}
+ 						else {
 							evaluator.evaluateFormulaCell(c);
-//						}
+ 						}
 					}
 				}
 			}


### PR DESCRIPTION
1. `AbstractExcelImporter.evaluateAllFormulaCells()` references `Cell.CELL_TYPE_FORMULA`. Instead, it should reference `CellType.FORMULA`. I suspect this worked at one time, but Apache-POI has since been updated.
2. I have also added an optional argument to `evaluateAllFormulaCells(boolean inCell = false)` that will call `evaluateInCell(c)` if true. Otherwise, it will call `evaluateFormulaCell(c)`. This fixes a problem I was encountering with formulas not being evaluated. I wrote this so that the default behavior has not changed, however, so it should not break any existing code.